### PR TITLE
Removes developer certificates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,6 @@ this could be a problem. That is why is recommended in such environments to use 
 
 To tell Carthage to use your own access token and in order for the bootstrap script to install the custom version of Carthage you need to define the environmental variable `GITHUB_ACCESS_TOKEN`.
 
-##### Code signing certificates
-
-Because Carthage builds all the dependencies and generates a fat `.framework` with binaries for all the possible architectures (iWatch, iPhone, simulator). It needs to sign the artifacts using a code signing certificate. There is an open [issue](https://github.com/Carthage/Carthage/pull/583) to solve this problem but for now you need to provide a `.p12` file with a development certificate and store them in `script/certificates/cibot.p12`. You will also need to provide the passphrase for the certificate in the environmental variable `KEY_PASSWORD`.
-
 ## License
 
 **ios-scripts** is available under the Apache 2.0 [license](https://raw.githubusercontent.com/guidomb/ios-scripts/master/LICENSE).

--- a/install
+++ b/install
@@ -129,16 +129,6 @@ install_scripts()
     generate_env_file $1
   fi
 
-  if [ -f $1/Cartfile ]
-  then
-    echo ""
-    echo " NOTE: Remember to add your .p12 in '$1/script/certificates'."
-    echo " For more information about why this is needed check:"
-    echo ""
-    echo "   https://github.com/Carthage/Carthage/pull/583"
-    echo ""
-  fi
-
   if [ -z "$can_commit_changes" ]
   then
     if [ ! -z "$(cd $1; git status --porcelain || echo '')" ]

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,99 +1,30 @@
 #!/bin/bash
 
-export SCRIPT_DIR=$(dirname "$0")
+echo ""
+echo "####### Bootstrap Phase #######"
+echo ""
+NO_CARTHAGE_UPDATE=true script/bootstrap
+status=$?
 
-##
-## Configuration Variables
-##
-
-# The name of the keychain to create for iOS code signing.
-KEYCHAIN=ios-build.keychain
-
-##
-## Build Process
-##
-
-main ()
-{
-    if [ -f Cartfile ]
+if [ $status -eq 0 ]
+then
+  echo ""
+  echo ""
+  echo "####### Build & Test Phase #######"
+  echo ""
+  set -o pipefail && script/test 2>&1 | tee /tmp/build.test-output.txt
+  status=$?
+  if [ ! $status -eq 0 ]
+  then
+    log_file_path=`cat /tmp/build.test-output.txt | tail -n 100 | perl -l -ne '/(\/var\/folders.*\/com\.apple\.dt\.XCTest-status.*)\)/ && print $1'`
+    if [ ! -z "$log_file_path" ]
     then
       echo ""
-      echo "####### Importing Developer Certificates #######"
+      echo " → The tests have failed. Printing output of log file '$log_file_path'."
+      cat $log_file_path
       echo ""
-      import_certs
     fi
+  fi
+fi
 
-    echo ""
-    echo "####### Bootstrap Phase #######"
-    echo ""
-    NO_CARTHAGE_UPDATE=true script/bootstrap
-    local status=$?
-
-    if [ $status -eq 0 ]
-    then
-      echo ""
-      echo ""
-      echo "####### Build & Test Phase #######"
-      echo ""
-      set -o pipefail && script/test 2>&1 | tee /tmp/build.test-output.txt
-      status=$?
-      if [ ! $status -eq 0 ]
-      then
-        log_file_path=`cat /tmp/build.test-output.txt | tail -n 100 | perl -l -ne '/(\/var\/folders.*\/com\.apple\.dt\.XCTest-status.*)\)/ && print $1'`
-        if [ ! -z "$log_file_path" ]
-        then
-          echo ""
-          echo " → The tests have failed. Printing output of log file '$log_file_path'."
-          cat $log_file_path
-          echo ""
-        fi
-      fi
-    fi
-
-    delete_keychain
-    exit $status
-}
-
-import_certs ()
-{
-    # If this environment variable is missing, we must not be running on Travis.
-    if [ -z "$KEY_PASSWORD" ]
-    then
-        return 0
-    fi
-
-    echo " → Setting up code signing..."
-    local password=cibuild
-
-    # Create a temporary keychain for code signing.
-    security create-keychain -p "$password" "$KEYCHAIN"
-    security default-keychain -s "$KEYCHAIN"
-    security unlock-keychain -p "$password" "$KEYCHAIN"
-    security set-keychain-settings -t 3600 -l "$KEYCHAIN"
-
-    # Download the certificate for the Apple Worldwide Developer Relations
-    # Certificate Authority.
-    local certpath="$SCRIPT_DIR/apple_wwdr.cer"
-    curl -s 'https://developer.apple.com/certificationauthority/AppleWWDRCA.cer' > "$certpath"
-    security import "$certpath" -k "$KEYCHAIN" -T /usr/bin/codesign
-
-    # Import our development certificate.
-    security import "$SCRIPT_DIR/certificates/cibot.p12" -k "$KEYCHAIN" -P "$KEY_PASSWORD" -T /usr/bin/codesign
-}
-
-delete_keychain ()
-{
-    if [ -z "$KEY_PASSWORD" ]
-    then
-        return 0
-    fi
-
-    echo " → Removing temporary keychain"
-    security delete-keychain "$KEYCHAIN"
-    echo "    ✔ Temporary keychain successfully removed."
-}
-
-export -f import_certs
-export -f delete_keychain
-
-main
+exit $status


### PR DESCRIPTION
Signing certificates are no longer needed for CI when using
Carthage.
