### PR TITLE
Parameter to enable/disable podspec lint

### DIFF
--- a/install
+++ b/install
@@ -106,6 +106,7 @@ generate_env_file ()
 REQUIRED_CARTHAGE_VERSION=$required_carthage_version
 CARTHAGE_BUILD_PLATFORM=\${CARTHAGE_BUILD_PLATFORM:-\"$carthage_platforms\"}
 CARTHAGE_NO_USE_BINARIES=\${CARTHAGE_NO_USE_BINARIES:-\"false\"}
+LINT_PODSPEC=\${LINT_PODSPEC:-\"yes\"}
 PROJECT_NAME=$project_name
 XCODE_WORKSPACE=$xcode_workspace_file
 XCODE_PROJECT=$xcode_project_file

--- a/script/test
+++ b/script/test
@@ -62,14 +62,14 @@ do
   run_tests $scheme
 done
 
-if [ -f "$PROJECT_NAME.podspec" ]
+if [ -f "$PROJECT_NAME.podspec" ] && [ "$LINT_PODSPEC" == "yes"]
 then
   echo ""
   echo " → Linting $PROJECT_NAME.podspec"
   echo ""
   if type bundle > /dev/null && bundle show pod > /dev/null
   then
-    bundle exec pod lib lint
+    bundle exec pod lib lint $LINT_PODSPEC_PARAMETERS
   elif type pod > /dev/null
   then
     pod lib lint

--- a/script/test
+++ b/script/test
@@ -72,6 +72,6 @@ then
     bundle exec pod lib lint $LINT_PODSPEC_PARAMETERS
   elif type pod > /dev/null
   then
-    pod lib lint
+    pod lib lint $LINT_PODSPEC_PARAMETERS
   fi
 fi


### PR DESCRIPTION
Allow to specify parameters when listing like `--allow-warnings`
