### PR TITLE
Fix tailor script broken due to change in how releases are named

### DIFF
--- a/script/common/tailor
+++ b/script/common/tailor
@@ -5,6 +5,7 @@ force_install_tailor ()
   echo ""
   wget https://github.com/sleekbyte/tailor/releases/download/v$REQUIRED_TAILOR_VERSION/tailor-$REQUIRED_TAILOR_VERSION.tar -O /tmp/tailor.tar > /dev/null
   tar -xvf /tmp/tailor.tar
+  mv tailor-$REQUIRED_TAILOR_VERSION/ tailor/
   export PATH=$PATH:$PWD/tailor/bin/
   echo "    ✔ tailor '$REQUIRED_TAILOR_VERSION' successfully installed"
   echo ""

--- a/script/common/tailor
+++ b/script/common/tailor
@@ -6,7 +6,7 @@ force_install_tailor ()
   wget https://github.com/sleekbyte/tailor/releases/download/v$REQUIRED_TAILOR_VERSION/tailor-$REQUIRED_TAILOR_VERSION.tar -O /tmp/tailor.tar > /dev/null
   tar -xvf /tmp/tailor.tar
   export PATH=$PATH:$PWD/tailor/bin/
-  echo "    ✔ swiftlint '$REQUIRED_TAILOR_VERSION' successfully installed"
+  echo "    ✔ tailor '$REQUIRED_TAILOR_VERSION' successfully installed"
   echo ""
 }
 


### PR DESCRIPTION
Tailor decided to change the name of the folder contained in the `tar` file downloaded from Github, adding the version as a suffix.

This change fixes this, and also fixes a copy paste error made when creating the script.
