### PR TITLE
Improving common/carthage and common/install_carthage

### DIFF
--- a/script/common/carthage
+++ b/script/common/carthage
@@ -1,13 +1,26 @@
 force_install_carthage ()
 {
   echo ""
-  echo " → Installing carthage '$REQUIRED_CARTHAGE_VERSION'"
+  echo " → Checking carthage version '$REQUIRED_CARTHAGE_VERSION'"
   echo ""
-  curl -s -L -O https://github.com/Carthage/Carthage/releases/download/$REQUIRED_CARTHAGE_VERSION/Carthage.pkg > /dev/null
-  sudo installer -pkg Carthage.pkg -target / > /dev/null
-  rm Carthage.pkg
-  echo "    ✔ carthage '$REQUIRED_CARTHAGE_VERSION' successfully installed"
-  echo ""
+  curl -s --head https://github.com/Carthage/Carthage/releases/download/$REQUIRED_CARTHAGE_VERSION/Carthage.pkg | head -n 1 | grep "HTTP/1.[01] [23].." > /dev/null
+  # on success (page exists), $? will be 0;
+  # on failure (page does not exist or is unreachable), $? will be 1
+  if [ "$?" -eq 0 ]
+  then
+    echo ""
+    echo " → Installing carthage '$REQUIRED_CARTHAGE_VERSION'"
+    echo ""
+    curl -s -L -O https://github.com/Carthage/Carthage/releases/download/$REQUIRED_CARTHAGE_VERSION/Carthage.pkg > /dev/null
+    sudo installer -pkg Carthage.pkg -target / > /dev/null
+    rm Carthage.pkg
+    echo "    ✔ carthage '$REQUIRED_CARTHAGE_VERSION' successfully installed"
+    echo ""
+  else
+    printf "\033[1;31mError: carthage version '$REQUIRED_CARTHAGE_VERSION' does not exist."
+    printf "\033[0m"
+    echo ""
+  fi
 }
 
 uninstall_carthage ()
@@ -65,6 +78,7 @@ check_carthage_version ()
           exit 1
         fi
       fi
+    fi
   else
     if [ "$carthage_installed_version" != "$COMPARE_CARTHAGE_VERSION" ]
     then

--- a/script/common/carthage
+++ b/script/common/carthage
@@ -1,4 +1,4 @@
-force_install_carthage ()
+check_carthage_version_exists ()
 {
   echo ""
   echo " → Checking carthage version '$REQUIRED_CARTHAGE_VERSION'"
@@ -8,19 +8,22 @@ force_install_carthage ()
   # on failure (page does not exist or is unreachable), $? will be 1
   if [ "$?" -eq 0 ]
   then
-    echo ""
-    echo " → Installing carthage '$REQUIRED_CARTHAGE_VERSION'"
-    echo ""
-    curl -s -L -O https://github.com/Carthage/Carthage/releases/download/$REQUIRED_CARTHAGE_VERSION/Carthage.pkg > /dev/null
-    sudo installer -pkg Carthage.pkg -target / > /dev/null
-    rm Carthage.pkg
-    echo "    ✔ carthage '$REQUIRED_CARTHAGE_VERSION' successfully installed"
-    echo ""
+    return 0
   else
-    printf "\033[1;31mError: carthage version '$REQUIRED_CARTHAGE_VERSION' does not exist."
-    printf "\033[0m"
-    echo ""
+    return 1
   fi
+}
+
+force_install_carthage ()
+{
+  echo ""
+  echo " → Installing carthage '$REQUIRED_CARTHAGE_VERSION'"
+  echo ""
+  curl -s -L -O https://github.com/Carthage/Carthage/releases/download/$REQUIRED_CARTHAGE_VERSION/Carthage.pkg > /dev/null
+  sudo installer -pkg Carthage.pkg -target / > /dev/null
+  rm Carthage.pkg
+  echo "    ✔ carthage '$REQUIRED_CARTHAGE_VERSION' successfully installed"
+  echo ""
 }
 
 uninstall_carthage ()
@@ -41,6 +44,14 @@ uninstall_carthage ()
 
 check_carthage_version ()
 {
+  if ! check_carthage_version_exists
+  then
+    printf "\033[1;31mError: carthage version '$REQUIRED_CARTHAGE_VERSION' does not exist."
+    printf "\033[0m"
+    echo ""
+    exit
+  fi
+
   local carthage_installed_version=`carthage version`
 
   local patch_number=`echo $REQUIRED_CARTHAGE_VERSION | cut -d "." -f 3`

--- a/script/common/carthage
+++ b/script/common/carthage
@@ -44,17 +44,14 @@ check_carthage_version ()
     carthage_installed_version="$carthage_installed_version.0"
   fi
 
-  if [ "$carthage_installed_version" != "$COMPARE_CARTHAGE_VERSION" ]
+  if [ "$carthage_installed_version" == ".0" ]
   then
-    printf "\033[1;31mError: carthage version '$carthage_installed_version' is not equal to '$COMPARE_CARTHAGE_VERSION'"
-    printf "\033[0m"
     if [ ! -z "$NO_CARTHAGE_UPDATE" ]
     then
       exit 1
     else
       if [ ! -z "$FORCE_CARTHAGE_VERSION" ]
       then
-        uninstall_carthage
         force_install_carthage
       else
         echo ""
@@ -63,10 +60,36 @@ check_carthage_version ()
         read update_carthage
         if [ "$update_carthage" == "y" ]
         then
-          uninstall_carthage
           force_install_carthage
         else
           exit 1
+        fi
+      fi
+  else
+    if [ "$carthage_installed_version" != "$COMPARE_CARTHAGE_VERSION" ]
+    then
+      printf "\033[1;31mError: carthage version '$carthage_installed_version' is not equal to '$COMPARE_CARTHAGE_VERSION'"
+      printf "\033[0m"
+      if [ ! -z "$NO_CARTHAGE_UPDATE" ]
+      then
+        exit 1
+      else
+        if [ ! -z "$FORCE_CARTHAGE_VERSION" ]
+        then
+          uninstall_carthage
+          force_install_carthage
+        else
+          echo ""
+          echo ""
+          echo "Would you like to update carthage to version '$REQUIRED_CARTHAGE_VERSION'? [N/y]"
+          read update_carthage
+          if [ "$update_carthage" == "y" ]
+          then
+            uninstall_carthage
+            force_install_carthage
+          else
+            exit 1
+          fi
         fi
       fi
     fi

--- a/script/common/install_carthage
+++ b/script/common/install_carthage
@@ -6,4 +6,4 @@ then
   echo "Enter the version of Carthage you want to install:"
   read REQUIRED_CARTHAGE_VERSION
 fi
-force_install_carthage
+check_carthage_version


### PR DESCRIPTION
## Summary
Improving common/carthage and common/install_carthage scripts.


### Before

When trying to install inexistent version, it said it had successfully installed, but my carthage version wasn't replaced.

![untitled](https://cloud.githubusercontent.com/assets/12351004/25101751/dd640c38-238b-11e7-8daa-16c137a53e2f.png)

### After

The install_carthage script before directly installed, instead of checking version that maybe made the installation unnecessary. So it now calls check_carthage_version.

Then, the carthage script's check_carthage_version function now checks if the wanted carthage version exists; if it does, then it proceeeds with the old process. Moreover, if there is no carthage installed it avoids uninstalling carthage.