### PR TITLE
Taking only last line of 'carthage version' into account

### DIFF
--- a/script/common/carthage
+++ b/script/common/carthage
@@ -53,6 +53,7 @@ check_carthage_version ()
   fi
 
   local carthage_installed_version=`carthage version`
+  carthage_installed_version=${carthage_installed_version##*$'\n'}
 
   local patch_number=`echo $REQUIRED_CARTHAGE_VERSION | cut -d "." -f 3`
   if [ -z $patch_number ]
@@ -117,6 +118,8 @@ check_carthage_version ()
           fi
         fi
       fi
+    else
+      echo "Carthage version '$REQUIRED_CARTHAGE_VERSION' is already installed."
     fi
   fi
 }

--- a/script/common/carthage
+++ b/script/common/carthage
@@ -32,6 +32,7 @@ uninstall_carthage ()
   echo " → Uninstalling carthage"
   echo ""
   local carthage_installed_version=`carthage version`
+  carthage_installed_version=${carthage_installed_version##*$'\n'}
   if type brew > /dev/null && [ ! -z "$(brew list --versions carthage)" ]
   then
     brew uninstall carthage > /dev/null


### PR DESCRIPTION
Lately `carthage version` command is returning messages like:
```
*** Please update to the latest Carthage version: 0.23.0. You currently are on 0.22.0
0.22.0
```

So the carthage version comparison is failing.

With this, we only compare with the last line of `carthage version`'s output, so it works for version with that update warning and without it.